### PR TITLE
Accept and pass string in setUserId

### DIFF
--- a/android/src/main/kotlin/com/raygun/raygun4flutter/raygun4flutter/Raygun4flutterPlugin.kt
+++ b/android/src/main/kotlin/com/raygun/raygun4flutter/raygun4flutter/Raygun4flutterPlugin.kt
@@ -81,9 +81,9 @@ class Raygun4flutterPlugin : FlutterPlugin, MethodCallHandler {
     }
 
     private fun onUserId(methodCall: MethodCall) {
-        val userId = methodCall.argument<Int>("userId")
+        val userId = methodCall.argument<String>("userId")
         val userInfo = userId?.let {
-            RaygunUserInfo(it.toString(), "", "", "");
+            RaygunUserInfo(it, "", "", "");
         } ?: RaygunUserInfo()
         RaygunClient.setUser(userInfo)
     }

--- a/ios/Classes/SwiftRaygun4flutterPlugin.swift
+++ b/ios/Classes/SwiftRaygun4flutterPlugin.swift
@@ -53,8 +53,8 @@ public class SwiftRaygun4flutterPlugin: NSObject, FlutterPlugin {
     }
 
     func setUserId(data: NSDictionary?, result: FlutterResult) {
-        if let userId = data?.value(forKey: "userId") as? Int {
-            RaygunClient.sharedInstance().userInformation = RaygunUserInformation.init(identifier: String(userId))
+        if let userId = data?.value(forKey: "userId") as? String {
+            RaygunClient.sharedInstance().userInformation = RaygunUserInformation.init(identifier: userId)
         } else {
             RaygunClient.sharedInstance().userInformation = RaygunUserInformation.anonymousUser
         }

--- a/lib/raygun4flutter.dart
+++ b/lib/raygun4flutter.dart
@@ -8,8 +8,7 @@ class Raygun {
   // Don't allow instances
   Raygun._();
 
-  static const _channel =
-      MethodChannel('com.raygun.raygun4flutter/raygun4flutter');
+  static const _channel = MethodChannel('com.raygun.raygun4flutter/raygun4flutter');
 
   static Future init(String apiKey) async {
     await _channel.invokeMethod('init', <String, String>{
@@ -37,10 +36,7 @@ class Raygun {
   ]) async {
     var traceLocations = '';
     if (stackTrace != null) {
-      traceLocations = Trace.from(stackTrace)
-          .frames
-          .map((frame) => '${frame.member}#${frame.location}')
-          .join(';');
+      traceLocations = Trace.from(stackTrace).frames.map((frame) => '${frame.member}#${frame.location}').join(';');
     }
 
     await _channel.invokeMethod('send', <String, String>{
@@ -58,9 +54,18 @@ class Raygun {
   }
 
   /// Sets User Id to Raygun
-  static Future setUserId(String userId) async {
+  static Future setUserId(dynamic userId) async {
+    String stringToSend;
+    if (userId is int) {
+      stringToSend = userId.toString();
+    } else if (userId is String) {
+      stringToSend = userId;
+    } else {
+      throw ("Error in setUserId: userId should be a String or int");
+    }
+
     await _channel.invokeMethod('userId', <String, String>{
-      'userId': userId,
+      'userId': stringToSend,
     });
   }
 }

--- a/lib/raygun4flutter.dart
+++ b/lib/raygun4flutter.dart
@@ -60,8 +60,6 @@ class Raygun {
       stringToSend = userId.toString();
     } else if (userId is String) {
       stringToSend = userId;
-    } else {
-      throw ("Error in setUserId: userId should be a String or int");
     }
 
     await _channel.invokeMethod('userId', <String, String>{


### PR DESCRIPTION
While testing on android I noticed that the `setUserId` method in dart
accepts a string, but when the `userId` value is sent down to the swift
and kotlin files the logic there checks to see if they are integers and
if they are it coerces them into strings and then sends the strings to
raygun. If they are not integers it sets an anonymous user.

This changes the dart method so it accepts a dynamic type, checks to
make sure that `userId` is a `String` or an `int` and coerces an `int`
into a string to send to the kotlin and swift classes.